### PR TITLE
Python packages fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN mkdir -p /home/$USER_NAME/.ssh && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN pip install -r https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt
-RUN pip install --upgrade requests
+RUN pip install cryptography==3.3
+RUN pip install requests~=2.25.1
 
 # Install Ansible collections
 COPY requirements.yml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN mkdir -p /home/$USER_NAME/.ssh && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN pip install -r https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt
+RUN pip install --upgrade requests
 
 # Install Ansible collections
 COPY requirements.yml .


### PR DESCRIPTION
The problem I mentioned the other day was:

```
ERROR: azure-cli-core 2.26.1 has requirement cryptography <3.4,> = 3.2, but you'll have cryptography 36.0.1 which is incompatible.
ERROR: azure-cli-core 2.26.1 has requirement requests ~ = 2.25.1, but you'll have requests 2.26.0 which is incompatible.
```

This has been resolved by installing the required versions that are compatible.